### PR TITLE
Fix pressure unit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,7 +820,7 @@ impl Default for Settings {
 pub struct Sample {
     /// Temperature reading in celsius.
     pub temperature: f32,
-    /// Pressure reading in kilo-pascals.
+    /// Pressure reading in pascal.
     pub pressure: f32,
     /// Humidity in perfect relative.
     pub humidity: f32,


### PR DESCRIPTION
The data sheet conversion function returns the pressure value in Q24.8 pascal. The code here only additionally converts from Q24.8 to f32.

A measured indoor value:
```
Sample { temperature: 23.63, pressure: 96452.01, humidity: 44.351563 }
```