### PR TITLE
Fix sign extension of h4 and h5 calibration value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,8 @@ impl From<[u8; NUM_CALIB_REG]> for Calibration {
             h1: buf[25],
             h2: i16::from_le_bytes([buf[26], buf[27]]),
             h3: buf[28],
-            h4: ((buf[29] as i16) << 4 | (buf[30] as i16) & 0xF),
-            h5: (((buf[30] as i16) & 0xF0) >> 4) | ((buf[31] as i16) << 4),
+            h4: ((buf[29] as i8 as i16) << 4 | (buf[30] as i8 as i16) & 0xF),
+            h5: (((buf[30] as i8 as i16) & 0xF0) >> 4) | ((buf[31] as i8 as i16) << 4),
             h6: buf[32] as i8,
         }
     }


### PR DESCRIPTION
The 12 bit signed values h4 and h5 are meant to be sign extended to signed 16 bit.
The data sheet is ambiguous about this, but the official driver provided by Bosch
does sign extension:

https://github.com/BoschSensortec/BME280_driver/blob/c47f06eb44fc96970f0abfcc941ec16425b2a9e6/bme280.c#L1528

Also see this example code for why this step cast makes a difference:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=5bbf4a28528f75f82d18d70e04505da2

`buf[30]` doesn't strictly need this step cast, but I included it for symmetry.