### PR TITLE
Add support for i2c on embedded-hal v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added an I2C implementation for `embedded-hal` version 1.
+
 ### Changed
 - Updated the alpha release of `embedded-hal` from `1.0.0-alpha.11` to `1.0.0-rc.1`.
 - Updated the alpha release of `embedded-hal-nb` from `1.0.0-alpha.3` to `1.0.0-rc.1`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ BME280 driver with support for I2C and SPI buses.
 ## Example
 
 ```rust
-use bme280_multibus::{i2c0::Address, Bme280, Sample, Standby};
+use bme280_multibus::{Address, Bme280, Sample, Standby};
 
 const SETTINGS: bme280_multibus::Settings = bme280_multibus::Settings {
     config: bme280_multibus::Config::RESET

--- a/examples/ftdi-i2c.rs
+++ b/examples/ftdi-i2c.rs
@@ -30,7 +30,7 @@ fn main() {
 
     let i2c: I2c<Ft232h> = hal_dev.i2c().unwrap();
 
-    let mut bme: Bme280<_> = Bme280::from_i2c0(i2c, bme280_multibus::i2c0::Address::SdoVddio)
+    let mut bme: Bme280<_> = Bme280::from_i2c0(i2c, bme280_multibus::Address::SdoVddio)
         .expect("Failed to initialize BME280");
     bme.reset().expect("Failed to reset");
 

--- a/src/i2c0.rs
+++ b/src/i2c0.rs
@@ -1,12 +1,4 @@
-/// I2C device address.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-#[repr(u8)]
-pub enum Address {
-    /// SDO pin is connected to GND.
-    SdoGnd = 0x76,
-    /// SDO pin is connected to V<sub>DDIO</sub>
-    SdoVddio = 0x77,
-}
+pub use super::Address;
 
 /// BME280 bus.
 #[derive(Debug)]

--- a/src/i2c1.rs
+++ b/src/i2c1.rs
@@ -1,0 +1,74 @@
+/// I2C device address.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[repr(u8)]
+pub enum Address {
+    /// SDO pin is connected to GND.
+    SdoGnd = 0x76,
+    /// SDO pin is connected to V<sub>DDIO</sub>
+    SdoVddio = 0x77,
+}
+
+/// BME280 bus.
+#[derive(Debug)]
+pub struct Bme280Bus<I2C> {
+    address: u8,
+    bus: I2C,
+}
+
+impl<I2C, E> Bme280Bus<I2C>
+where
+    I2C: eh1::i2c::I2c<Error = E>,
+{
+    /// Creates a new `Bme280Bus` from a I2C peripheral, and an I2C
+    /// device address.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let i2c = ehm::eh1::i2c::Mock::new(&[]);
+    /// use bme280_multibus::i2c1::{Address, Bme280Bus};
+    ///
+    /// let mut bme: Bme280Bus<_> = Bme280Bus::new(i2c, Address::SdoGnd);
+    /// # let mut i2c = bme.free();
+    /// # i2c.done();
+    /// ```
+    #[inline]
+    pub fn new(bus: I2C, address: Address) -> Self {
+        Self {
+            bus,
+            address: address as u8,
+        }
+    }
+
+    /// Free the I2C bus from the BME280.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let i2c = ehm::eh1::i2c::Mock::new(&[]);
+    /// use bme280_multibus::i2c1::{Address, Bme280Bus};
+    ///
+    /// let mut bme: Bme280Bus<_> = Bme280Bus::new(i2c, Address::SdoGnd);
+    /// let mut i2c = bme.free();
+    /// # i2c.done();
+    /// ```
+    #[inline]
+    pub fn free(self) -> I2C {
+        self.bus
+    }
+}
+
+impl<I2C, E> crate::Bme280Bus for Bme280Bus<I2C>
+where
+    I2C: eh1::i2c::I2c<Error = E>,
+{
+    type Error = E;
+
+    fn read_regs(&mut self, reg: u8, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.bus.write_read(self.address, &[reg], buf)
+    }
+
+    fn write_reg(&mut self, reg: u8, data: u8) -> Result<(), Self::Error> {
+        self.bus.write(self.address, &[reg, data])
+    }
+}

--- a/src/i2c1.rs
+++ b/src/i2c1.rs
@@ -1,12 +1,4 @@
-/// I2C device address.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-#[repr(u8)]
-pub enum Address {
-    /// SDO pin is connected to GND.
-    SdoGnd = 0x76,
-    /// SDO pin is connected to V<sub>DDIO</sub>
-    SdoVddio = 0x77,
-}
+pub use super::Address;
 
 /// BME280 bus.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,13 @@ pub use eh1;
 #[cfg(feature = "async")]
 pub use eha0a;
 
-/// BME280 I2C bus implementation with embedded-val version 0.2
+/// BME280 I2C bus implementation with embedded-hal version 0.2
 pub mod i2c0;
-/// BME280 SPI bus implementation with embedded-val version 0.2
+/// BME280 I2C bus implementation with embedded-hal version 1
+pub mod i2c1;
+/// BME280 SPI bus implementation with embedded-hal version 0.2
 pub mod spi0;
-/// BME280 SPI bus implementation with embedded-val version 1
+/// BME280 SPI bus implementation with embedded-hal version 1
 pub mod spi1;
 
 /// BME280 chip ID.
@@ -1078,6 +1080,32 @@ where
     /// ```
     pub fn from_i2c0(i2c: I2C, address: crate::i2c0::Address) -> Result<Self, E> {
         let bus = crate::i2c0::Bme280Bus::new(i2c, address);
+        Self::new(bus)
+    }
+}
+
+impl<I2C, E> Bme280<crate::i2c1::Bme280Bus<I2C>>
+where
+    I2C: eh1::i2c::I2c<Error = E>,
+{
+    /// Creates a new `Bme280` driver from a I2C peripheral, and an I2C
+    /// device address.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let i2c = ehm::eh1::i2c::Mock::new(&[
+    /// #   ehm::eh1::i2c::Transaction::write_read(0x76, vec![0x88], vec![0; 26]),
+    /// #   ehm::eh1::i2c::Transaction::write_read(0x76, vec![0xE1], vec![0; 7]),
+    /// # ]);
+    /// use bme280_multibus::{i2c1::Address, Bme280};
+    ///
+    /// let mut bme: Bme280<_> = Bme280::from_i2c1(i2c, Address::SdoGnd)?;
+    /// # bme.free().free().done();
+    /// # Ok::<(), ehm::eh1::MockError>(())
+    /// ```
+    pub fn from_i2c1(i2c: I2C, address: crate::i2c1::Address) -> Result<Self, E> {
+        let bus = crate::i2c1::Bme280Bus::new(i2c, address);
         Self::new(bus)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1112,7 +1112,7 @@ where
     ///
     /// let mut bme: Bme280<_> = Bme280::from_i2c1(i2c, Address::SdoGnd)?;
     /// # bme.free().free().done();
-    /// # Ok::<(), ehm::eh1::MockError>(())
+    /// # Ok::<(), eh1::i2c::ErrorKind>(())
     /// ```
     pub fn from_i2c1(i2c: I2C, address: crate::i2c1::Address) -> Result<Self, E> {
         let bus = crate::i2c1::Bme280Bus::new(i2c, address);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -908,6 +908,16 @@ impl Sample {
     }
 }
 
+/// I2C device address.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[repr(u8)]
+pub enum Address {
+    /// SDO pin is connected to GND.
+    SdoGnd = 0x76,
+    /// SDO pin is connected to V<sub>DDIO</sub>
+    SdoVddio = 0x77,
+}
+
 /// Sampling error.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error<B> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1659,7 +1659,7 @@ where
     /// #   ehm::eh0::i2c::Transaction::write(0x76, vec![0xF5, 0b10110000]),
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xF7], vec![0; 8]),
     /// # ]);
-    /// use bme280_multibus::{i2c0::Address, Bme280, Sample, Standby};
+    /// use bme280_multibus::{i2c0::Address, Bme280, Sample};
     ///
     /// const SETTINGS: bme280_multibus::Settings = bme280_multibus::Settings {
     ///     config: bme280_multibus::Config::RESET

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! #   ehm::eh0::i2c::Transaction::write(0x76, vec![0xF5, 0b10110000]),
 //! #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xF7], vec![0; 8]),
 //! # ]);
-//! use bme280_multibus::{i2c0::Address, Bme280, Sample, Standby};
+//! use bme280_multibus::{Address, Bme280, Sample, Standby};
 //!
 //! const SETTINGS: bme280_multibus::Settings = bme280_multibus::Settings {
 //!     config: bme280_multibus::Config::RESET
@@ -1082,13 +1082,13 @@ where
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0x88], vec![0; 26]),
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xE1], vec![0; 7]),
     /// # ]);
-    /// use bme280_multibus::{i2c0::Address, Bme280};
+    /// use bme280_multibus::{Address, Bme280};
     ///
     /// let mut bme: Bme280<_> = Bme280::from_i2c0(i2c, Address::SdoGnd)?;
     /// # bme.free().free().done();
     /// # Ok::<(), ehm::eh0::MockError>(())
     /// ```
-    pub fn from_i2c0(i2c: I2C, address: crate::i2c0::Address) -> Result<Self, E> {
+    pub fn from_i2c0(i2c: I2C, address: crate::Address) -> Result<Self, E> {
         let bus = crate::i2c0::Bme280Bus::new(i2c, address);
         Self::new(bus)
     }
@@ -1548,7 +1548,7 @@ where
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xE1], vec![0; 7]),
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xD0], vec![0x60]),
     /// # ]);
-    /// use bme280_multibus::{i2c0::Address, Bme280, CHIP_ID};
+    /// use bme280_multibus::{Address, Bme280, CHIP_ID};
     ///
     /// let mut bme: Bme280<_> = Bme280::from_i2c0(i2c, Address::SdoGnd)?;
     /// let chip_id: u8 = bme.chip_id()?;
@@ -1572,7 +1572,7 @@ where
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xE1], vec![0; 7]),
     /// #   ehm::eh0::i2c::Transaction::write(0x76, vec![0xE0, 0xB6]),
     /// # ]);
-    /// use bme280_multibus::{i2c0::Address, Bme280};
+    /// use bme280_multibus::{Address, Bme280};
     ///
     /// let mut bme: Bme280<_> = Bme280::from_i2c0(i2c, Address::SdoGnd)?;
     /// bme.reset()?;
@@ -1595,7 +1595,7 @@ where
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xE1], vec![0; 7]),
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xF3], vec![0]),
     /// # ]);
-    /// use bme280_multibus::{i2c0::Address, Bme280, Status};
+    /// use bme280_multibus::{Address, Bme280, Status};
     ///
     /// let mut bme: Bme280<_> = Bme280::from_i2c0(i2c, Address::SdoGnd)?;
     /// let status: Status = bme.status()?;
@@ -1621,7 +1621,7 @@ where
     /// #   ehm::eh0::i2c::Transaction::write(0x76, vec![0xF5, 0b10110000]),
     /// # ]);
     /// use bme280_multibus::{
-    ///     i2c0::Address, Bme280, Config, CtrlMeas, Filter, Mode, Oversampling, Settings, Standby,
+    ///     Address, Bme280, Config, CtrlMeas, Filter, Mode, Oversampling, Settings, Standby,
     /// };
     ///
     /// const SETTINGS: Settings = Settings {
@@ -1659,7 +1659,7 @@ where
     /// #   ehm::eh0::i2c::Transaction::write(0x76, vec![0xF5, 0b10110000]),
     /// #   ehm::eh0::i2c::Transaction::write_read(0x76, vec![0xF7], vec![0; 8]),
     /// # ]);
-    /// use bme280_multibus::{i2c0::Address, Bme280, Sample};
+    /// use bme280_multibus::{Address, Bme280, Sample};
     ///
     /// const SETTINGS: bme280_multibus::Settings = bme280_multibus::Settings {
     ///     config: bme280_multibus::Config::RESET

--- a/tests/i2c1.rs
+++ b/tests/i2c1.rs
@@ -1,0 +1,29 @@
+use bme280_multibus::{i2c0::Address, Bme280, Sample};
+
+#[test]
+fn i2c1_sample() {
+    let i2c = ehm::eh1::i2c::Mock::new(&[
+        ehm::eh1::i2c::Transaction::write_read(0x76, vec![0x88], vec![0; 26]),
+        ehm::eh1::i2c::Transaction::write_read(0x76, vec![0xE1], vec![0; 7]),
+        ehm::eh1::i2c::Transaction::write(0x76, vec![0xF2, 0b100]),
+        ehm::eh1::i2c::Transaction::write(0x76, vec![0xF4, 0b10010011]),
+        ehm::eh1::i2c::Transaction::write(0x76, vec![0xF5, 0b10110000]),
+        ehm::eh1::i2c::Transaction::write_read(0x76, vec![0xF7], vec![0; 8]),
+    ]);
+
+    const SETTINGS: bme280_multibus::Settings = bme280_multibus::Settings {
+        config: bme280_multibus::Config::RESET
+            .set_standby_time(bme280_multibus::Standby::Millis1000)
+            .set_filter(bme280_multibus::Filter::X16),
+        ctrl_meas: bme280_multibus::CtrlMeas::RESET
+            .set_osrs_t(bme280_multibus::Oversampling::X8)
+            .set_osrs_p(bme280_multibus::Oversampling::X8)
+            .set_mode(bme280_multibus::Mode::Normal),
+        ctrl_hum: bme280_multibus::Oversampling::X8,
+    };
+
+    let mut bme: Bme280<_> = Bme280::from_i2c1(i2c, Address::SdoGnd).unwrap();
+    bme.settings(&SETTINGS).unwrap();
+    let _sample: Sample = bme.sample().unwrap();
+    bme.free().free().done();
+}

--- a/tests/i2c1.rs
+++ b/tests/i2c1.rs
@@ -1,4 +1,4 @@
-use bme280_multibus::{i2c0::Address, Bme280, Sample};
+use bme280_multibus::{Address, Bme280, Sample};
 
 #[test]
 fn i2c1_sample() {


### PR DESCRIPTION
Implement embedded-hal v1.0.0-rc.1 I2C traits.
Tested on ESP32.